### PR TITLE
Remove scheme and use DefaultUnstructuredConverter

### DIFF
--- a/status/checker_test.go
+++ b/status/checker_test.go
@@ -54,7 +54,7 @@ func TestCheck(t *testing.T) {
 
 			// Register negative polarity conditions with the checker.
 			conditions := &Conditions{NegativePolarity: []string{"TestCondition1", "TestCondition2"}}
-			checker := NewChecker(builder.Build(), scheme, conditions)
+			checker := NewChecker(builder.Build(), conditions)
 			checker.DisableFetch = tt.disableFetch
 
 			fail, warn := checker.Check(context.TODO(), objOld)

--- a/status/doc.go
+++ b/status/doc.go
@@ -12,8 +12,6 @@
 //  )
 //
 //  func TestFoo() {
-//      scheme := runtime.NewScheme()
-//
 //      obj := &testapi.Obj{}
 //      obj.Name = "test-obj"
 //      obj.Namespace = "test-ns"
@@ -25,7 +23,7 @@
 //      // case, TestCondition1 and TestCondition2 are the negative polarity
 //      // conditions supported by the Obj controller.
 //      conditions := &status.Conditions{NegativePolarity: []string{"TestCondition1", "TestCondition2"}}
-//      checker := status.NewChecker(client, scheme, conditions)
+//      checker := status.NewChecker(client, conditions)
 //
 //      // Check object status.
 //      checker.CheckErr(context.TODO(), obj)

--- a/status/fail.go
+++ b/status/fail.go
@@ -7,11 +7,10 @@ import (
 	"github.com/fluxcd/pkg/apis/meta"
 	"github.com/fluxcd/pkg/runtime/conditions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Negative polarity condition cannot be True when Ready condition is True.
-func check_FAIL0001(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0001(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.IsTrue(obj, meta.ReadyCondition) {
 		return nil
 	}
@@ -37,7 +36,7 @@ func check_FAIL0001(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // Ready condition must always be present.
-func check_FAIL0002(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0002(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.Has(obj, meta.ReadyCondition) {
 		return fmt.Errorf("Ready condition must always be present")
 	}
@@ -45,7 +44,7 @@ func check_FAIL0002(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // Ready condition must be False when Reconciling condition is True.
-func check_FAIL0003(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0003(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.Has(obj, meta.ReconcilingCondition) {
 		return nil
 	}
@@ -62,7 +61,7 @@ func check_FAIL0003(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // Ready condition must be False when Stalled condition is True.
-func check_FAIL0004(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0004(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.Has(obj, meta.StalledCondition) {
 		return nil
 	}
@@ -80,7 +79,7 @@ func check_FAIL0004(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 
 // Only one of Reconciling condition or Stalled condition must be present at a
 // time.
-func check_FAIL0005(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0005(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if conditions.Has(obj, meta.ReconcilingCondition) && conditions.Has(obj, meta.StalledCondition) {
 		return fmt.Errorf("Only one of Reconciling condition or Stalled condition must be present at a time")
 	}
@@ -88,8 +87,8 @@ func check_FAIL0005(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // The ObservedGeneration must be less than or equal to the object Generation.
-func check_FAIL0006(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
-	og, err := getStatusObservedGeneration(scheme, obj)
+func check_FAIL0006(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
+	og, err := getStatusObservedGeneration(obj)
 	if err != nil {
 		return fmt.Errorf("CHECK_FAIL0006: failed to get observed generation: %w", err)
 	}
@@ -101,8 +100,8 @@ func check_FAIL0006(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 
 // Ready condition must be False when the ObservedGeneration is less than the
 // object Generation.
-func check_FAIL0007(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
-	og, err := getStatusObservedGeneration(scheme, obj)
+func check_FAIL0007(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
+	og, err := getStatusObservedGeneration(obj)
 	if err != nil {
 		return fmt.Errorf("CHECK_FAIL0007: failed to get observed generation: %w", err)
 	}
@@ -116,7 +115,7 @@ func check_FAIL0007(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 
 // Ready condition must be False when any of the status condition's
 // ObservedGeneration is less than the object Generation.
-func check_FAIL0008(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0008(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.IsReady(obj) {
 		return nil
 	}
@@ -136,11 +135,11 @@ func check_FAIL0008(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 
 // The status conditions' ObservedGenerations must be equal to the root
 // ObservedGeneration when Ready condition is True.
-func check_FAIL0009(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0009(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.IsReady(obj) {
 		return nil
 	}
-	og, err := getStatusObservedGeneration(scheme, obj)
+	og, err := getStatusObservedGeneration(obj)
 	if err != nil {
 		return fmt.Errorf("CHECK_FAIL0009: failed to get observed generation: %w", err)
 	}
@@ -159,11 +158,11 @@ func check_FAIL0009(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 
 // The root ObservedGeneration must be less than the Reconciling condition
 // ObservedGeneration when it Reconciling condition is True.
-func check_FAIL0010(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_FAIL0010(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.IsReconciling(obj) {
 		return nil
 	}
-	og, err := getStatusObservedGeneration(scheme, obj)
+	og, err := getStatusObservedGeneration(obj)
 	if err != nil {
 		return fmt.Errorf("CHECK_FAIL0010: failed to get observed generation: %w", err)
 	}

--- a/status/fail_test.go
+++ b/status/fail_test.go
@@ -72,7 +72,7 @@ func Test_check_FAIL0001(t *testing.T) {
 			}
 
 			condns := &Conditions{NegativePolarity: tt.negativePolarity}
-			err := check_FAIL0001(context.TODO(), nil, obj, condns)
+			err := check_FAIL0001(context.TODO(), obj, condns)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 
 			if tt.errCheck != nil {
@@ -114,7 +114,7 @@ func Test_check_FAIL0002(t *testing.T) {
 				tt.addConditions(obj)
 			}
 
-			err := check_FAIL0002(context.TODO(), nil, obj, nil)
+			err := check_FAIL0002(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -171,7 +171,7 @@ func Test_check_FAIL0003(t *testing.T) {
 			if tt.addConditions != nil {
 				tt.addConditions(obj)
 			}
-			err := check_FAIL0003(context.TODO(), nil, obj, nil)
+			err := check_FAIL0003(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -228,7 +228,7 @@ func Test_check_FAIL0004(t *testing.T) {
 			if tt.addConditions != nil {
 				tt.addConditions(obj)
 			}
-			err := check_FAIL0004(context.TODO(), nil, obj, nil)
+			err := check_FAIL0004(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -277,7 +277,7 @@ func Test_check_FAIL0005(t *testing.T) {
 			if tt.addConditions != nil {
 				tt.addConditions(obj)
 			}
-			err := check_FAIL0005(context.TODO(), nil, obj, nil)
+			err := check_FAIL0005(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -319,7 +319,7 @@ func Test_check_FAIL0006(t *testing.T) {
 			obj.SetGeneration(tt.objectGeneration)
 			obj.Status.ObservedGeneration = tt.observedGeneration
 
-			err := check_FAIL0006(context.TODO(), scheme, obj, nil)
+			err := check_FAIL0006(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -376,7 +376,7 @@ func Test_check_FAIL0007(t *testing.T) {
 				tt.addConditions(obj)
 			}
 
-			err := check_FAIL0007(context.TODO(), scheme, obj, nil)
+			err := check_FAIL0007(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -452,7 +452,7 @@ func Test_check_FAIL0008(t *testing.T) {
 			obj.SetGeneration(tt.objectGeneration)
 			obj.SetConditions(tt.conditions)
 
-			err := check_FAIL0008(context.TODO(), nil, obj, nil)
+			err := check_FAIL0008(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 
 			if tt.errCheck != nil {
@@ -536,7 +536,7 @@ func Test_check_FAIL0009(t *testing.T) {
 			obj.Status.ObservedGeneration = tt.rootObservedGeneration
 			obj.SetConditions(tt.conditions)
 
-			err := check_FAIL0009(context.TODO(), scheme, obj, nil)
+			err := check_FAIL0009(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 
 			if tt.errCheck != nil {
@@ -600,7 +600,7 @@ func Test_check_FAIL0010(t *testing.T) {
 			obj.Status.ObservedGeneration = tt.rootObservedGeneration
 			obj.SetConditions(tt.conditions)
 
-			err := check_FAIL0010(context.TODO(), scheme, obj, nil)
+			err := check_FAIL0010(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}

--- a/status/warn.go
+++ b/status/warn.go
@@ -8,11 +8,10 @@ import (
 	"github.com/fluxcd/pkg/runtime/conditions"
 	"github.com/kylelemons/godebug/pretty"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // Negative polarity condition present when Ready condition is True.
-func check_WARN0001(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_WARN0001(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.IsTrue(obj, meta.ReadyCondition) {
 		return nil
 	}
@@ -37,7 +36,7 @@ func check_WARN0001(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 
 // Ready condition should have the value of the negative polarity conditon
 // that's present with the highest priority.
-func check_WARN0002(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_WARN0002(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if conditions.IsTrue(obj, meta.ReadyCondition) {
 		return nil
 	}
@@ -63,7 +62,7 @@ func check_WARN0002(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // Reconciling condition can be removed when its value is False.
-func check_WARN0003(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_WARN0003(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.Has(obj, meta.ReconcilingCondition) {
 		return nil
 	}
@@ -75,7 +74,7 @@ func check_WARN0003(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // Stalled condition can be removed when its value is False.
-func check_WARN0004(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_WARN0004(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	if !conditions.Has(obj, meta.StalledCondition) {
 		return nil
 	}
@@ -87,7 +86,7 @@ func check_WARN0004(ctx context.Context, scheme *runtime.Scheme, obj conditions.
 }
 
 // Missing ObservedGeneration from status condition.
-func check_WARN0005(ctx context.Context, scheme *runtime.Scheme, obj conditions.Getter, condns *Conditions) error {
+func check_WARN0005(ctx context.Context, obj conditions.Getter, condns *Conditions) error {
 	probConditions := []string{}
 	for _, c := range obj.GetConditions() {
 		if c.ObservedGeneration < 1 {

--- a/status/warn_test.go
+++ b/status/warn_test.go
@@ -63,7 +63,7 @@ func Test_check_WARN0001(t *testing.T) {
 			}
 
 			condns := &Conditions{NegativePolarity: tt.negativePolarity}
-			err := check_WARN0001(context.TODO(), nil, obj, condns)
+			err := check_WARN0001(context.TODO(), obj, condns)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -141,7 +141,7 @@ func Test_check_WARN0002(t *testing.T) {
 			}
 
 			condns := &Conditions{NegativePolarity: tt.negativePolarity}
-			err := check_WARN0002(context.TODO(), nil, obj, condns)
+			err := check_WARN0002(context.TODO(), obj, condns)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 
 			if tt.errCheck != nil {
@@ -187,7 +187,7 @@ func Test_check_WARN0003(t *testing.T) {
 			if tt.addConditions != nil {
 				tt.addConditions(obj)
 			}
-			err := check_WARN0003(context.TODO(), nil, obj, nil)
+			err := check_WARN0003(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -229,7 +229,7 @@ func Test_check_WARN0004(t *testing.T) {
 			if tt.addConditions != nil {
 				tt.addConditions(obj)
 			}
-			err := check_WARN0004(context.TODO(), nil, obj, nil)
+			err := check_WARN0004(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}
@@ -278,7 +278,7 @@ func Test_check_WARN0005(t *testing.T) {
 			g := NewWithT(t)
 			obj := &testdata.Fake{}
 			obj.SetConditions(tt.conditions)
-			err := check_WARN0005(context.TODO(), nil, obj, nil)
+			err := check_WARN0005(context.TODO(), obj, nil)
 			g.Expect(err != nil).To(Equal(tt.wantErr))
 		})
 	}


### PR DESCRIPTION
Use `DefaultUnstructuredConverter` for converting `runtime.Object` into
`unstructured.Unstructured` instead of requiring a scheme.